### PR TITLE
Update 0018-odometry-use-in-optimization-problem.md

### DIFF
--- a/text/0018-odometry-use-in-optimization-problem.md
+++ b/text/0018-odometry-use-in-optimization-problem.md
@@ -61,13 +61,6 @@ Current upstream, i.e. implicit odometry-based constraints:
 Proposed explicit, separate weighting:
 ![upstream](0018-assets/raw-pointcloud_separate_constraints.png)
 
-The only parameters added for the new approach were:
-```lua
-POSE_GRAPH.optimization_problem.initial_pose_translation_weight = 1e5
-POSE_GRAPH.optimization_problem.initial_pose_rotation_weight = 1e5
-POSE_GRAPH.optimization_problem.odometry_translation_weight = 1e5
-POSE_GRAPH.optimization_problem.odometry_rotation_weight = 1e1
-```
 
 The new parameterization gives the flexibility to down-weight the rotation of the  wheel odometry (which we don't trust too much), while still benefiting from the strong rotation estimates of local slam and the high-resolution translation of the wheel odometry.
 


### PR DESCRIPTION
Thank you for commenting how to use wheel odometry at pose graph constraint.
Could you update below four parameters' name, because there aren't these parameters?

The only parameters added for the new approach were:
```lua
POSE_GRAPH.optimization_problem.initial_pose_translation_weight = 1e5
POSE_GRAPH.optimization_problem.initial_pose_rotation_weight = 1e5
POSE_GRAPH.optimization_problem.odometry_translation_weight = 1e5
POSE_GRAPH.optimization_problem.odometry_rotation_weight = 1e1
```